### PR TITLE
Fix for inline comments after variable declarations.

### DIFF
--- a/Sniffs/Commenting/PropertyCommentSniff.php
+++ b/Sniffs/Commenting/PropertyCommentSniff.php
@@ -146,12 +146,19 @@ class MO4_Sniffs_Commenting_PropertyCommentSniff
                 }
             }//end if
         } else if ($code === T_COMMENT) {
-            $commentStart = $phpcsFile->findPrevious(T_COMMENT, $commentEnd, null, true);
-            $phpcsFile->addError(
-                'property doc comment must begin with /**',
-                ($commentStart + 1),
-                'NotADocBlock'
-            );
+            // It seems that when we are in here, then we have a line comment at $commentEnd.
+            // Now, check if the same comment has a variable definition on the same line.
+            // If yes, it doesn't count.
+            $firstOnLine = $phpcsFile->findFirstOnLine(array(T_VARIABLE, T_CONST), $commentEnd);
+
+            if ($firstOnLine === false) {
+                $commentStart = $phpcsFile->findPrevious(T_COMMENT, $commentEnd, null, true);
+                $phpcsFile->addError(
+                    'property doc comment must begin with /**',
+                    ($commentStart + 1),
+                    'NotADocBlock'
+                );
+            }
         }//end if
 
     }//end processTokenWithinScope()

--- a/Tests/Commenting/PropertyCommentUnitTest.fail.inc
+++ b/Tests/Commenting/PropertyCommentUnitTest.fail.inc
@@ -33,4 +33,11 @@ class X
 
     // no doc block
     private $_otherPriv;
+
+    private $z = null; /* invalid
+                         multiline
+                         comment */
+
+    private $y = null; /** invalid doc block y is null by default */
+    private $x = null;
 }

--- a/Tests/Commenting/PropertyCommentUnitTest.fail.inc.fixed
+++ b/Tests/Commenting/PropertyCommentUnitTest.fail.inc.fixed
@@ -35,4 +35,11 @@ class X
 
     // no doc block
     private $_otherPriv;
+
+    private $z = null; /* invalid
+                         multiline
+                         comment */
+
+    private $y = null; /** invalid doc block y is null by default */
+    private $x = null;
 }

--- a/Tests/Commenting/PropertyCommentUnitTest.pass.inc
+++ b/Tests/Commenting/PropertyCommentUnitTest.pass.inc
@@ -10,7 +10,12 @@ class X
     /**
      * @var int
      */
-    public $publicProperty = 1;
+    public $publicProperty = 1; // Random comment
+    private $foo = 15; //add
+    private $bar = null; //delete
+    private $baz = 16; //change
+    const MUH = 'KUH'; // even more wat
+    public static $whatever = 'foobar'; // wat
 
     /**
      * array of foo => bar arrays

--- a/Tests/Commenting/PropertyCommentUnitTest.pass.inc
+++ b/Tests/Commenting/PropertyCommentUnitTest.pass.inc
@@ -13,9 +13,10 @@ class X
     public $publicProperty = 1; // Random comment
     private $foo = 15; //add
     private $bar = null; //delete
-    private $baz = 16; //change
     const MUH = 'KUH'; // even more wat
+    private $y = null; /* y is null by default */
     public static $whatever = 'foobar'; // wat
+    private $baz = 16; //change
 
     /**
      * array of foo => bar arrays

--- a/Tests/Commenting/PropertyCommentUnitTest.php
+++ b/Tests/Commenting/PropertyCommentUnitTest.php
@@ -51,6 +51,8 @@ class MO4_Tests_Commenting_PropertyCommentUnitTest extends AbstractSniffUnitTest
                 26 => 2,
                 29 => 1,
                 34 => 1,
+                37 => 1,
+                41 => 1,
             );
         }
 


### PR DESCRIPTION
The code sniffer should no longer consider line comments after variables to be faulty docblocks of the variable in the next line