### PR TITLE
Spelling corrections in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ Requires
 
 The MO4 Coding Standard is an extension of the [Symfony Coding Standard](http://symfony.com/doc/current/contributing/code/standards.html) and adds following rules:
 
-* short tags "[...]" must be used instead of  "array(...)",
-* in associates arrays, the "=>" operators must be aligned,
-* in arrays, the key and '=>' operator must be on the same line.
-* each consecutive variable assignements must align on the assigment operator,
-* use statements must be sorted,
-* you should use the imported class name, whenever it was imported with a use statement,
-* variables in double quoted strings must be surrounded by { }, e.g. "{$VAR}" instead of "$VAR",
-* sprintf or "{$VAR1} {$VAR2}" must be used instead of the concat operator, concat opetor are only allowed to concat constant an multi line strings,
-* a white space is requried after each cast opetor, e.g. "(int) $value" instead of "(int)$value",
+* short tags "[...]" must be used instead of  "array(...)"
+* in associates arrays, the "=>" operators must be aligned
+* in arrays, the key and '=>' operator must be on the same line
+* each consecutive variable assignments must align on the assignment operator
+* use statements must be sorted
+* you should use the imported class name, whenever it was imported with a use statement
+* variables in double quoted strings must be surrounded by { }, e.g. "{$VAR}" instead of "$VAR"
+* sprintf or "{$VAR1} {$VAR2}" must be used instead of the concat operator, concat operators are only allowed to concat constants and multi line strings,
+* a white space is required after each cast operator, e.g. "(int) $value" instead of "(int)$value",
 
 
 ## Installation
@@ -67,6 +67,6 @@ The unit-tests are run from within the PHP_CodeSniffer directory
 ## Credit
 
 
-## Licence
+## License
 
 This project is licensed under the MIT license.


### PR DESCRIPTION
There were some spelling errors and trailing commas in the enumeration.