### PR TITLE
include Unnecessary String Concat sniff

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -18,5 +18,10 @@
             <property name="error" value="true"/>
         </properties>
     </rule>
+    <rule ref="Generic.Strings.UnnecessaryStringConcat">
+        <properties>
+            <property name="allowMultiline" value="true"/>
+        </properties>
+    </rule>
 </ruleset>
 


### PR DESCRIPTION
This includes 

https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Generic/Sniffs/Strings/UnnecessaryStringConcatSniff.php
https://github.com/squizlabs/PHP_CodeSniffer/tree/master/CodeSniffer/Standards/Generic/Tests/Strings

to MO4.

MO4 is more restrictive about the concatenation operator, but this is a good starting point.