### PR TITLE
travis: add PHP 7.1, disable xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 before_script:
+  - phpenv config-rm xdebug.ini ; exit 0
   - composer install --dev
   - mkdir -p vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/MO4
   - cp ruleset.xml vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/MO4/


### PR DESCRIPTION
On PHP 7.1 and HHVM this is failing, so always exit with 0.