### PR TITLE
set dependency_paths to vendor/ for scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,5 +6,4 @@ filter:
   excluded_paths:
     - "MO4/Tests/*/*.inc"
   dependency_paths:
-    - "vendor/squizlabs/php_codesniffer/src/"
-    - "vendor/squizlabs/php_codesniffer/tests/Standards"
+    - "vendor/"


### PR DESCRIPTION
had to clean the cache on scruntinizer website
after the change to take effect.