### PR TITLE
tests: improve descriptiveness of docblock comments

### DIFF
--- a/MO4/Tests/Commenting/PropertyCommentUnitTest.fail.inc
+++ b/MO4/Tests/Commenting/PropertyCommentUnitTest.fail.inc
@@ -38,7 +38,7 @@ class X
                          multiline
                          comment */
 
-    private $y = null; /** invalid doc block y is null by default */
+    private $y = null; /** invalid doc block after declaration */
     private $q = null; /* valid single line comment */
     private $x = null;
     private $u = null; /* invalid

--- a/MO4/Tests/Commenting/PropertyCommentUnitTest.fail.inc.fixed
+++ b/MO4/Tests/Commenting/PropertyCommentUnitTest.fail.inc.fixed
@@ -40,7 +40,7 @@ class X
                          multiline
                          comment */
 
-    private $y = null; /** invalid doc block y is null by default */
+    private $y = null; /** invalid doc block after declaration */
     private $q = null; /* valid single line comment */
     private $x = null;
     private $u = null; /* invalid


### PR DESCRIPTION
Initially discussed in https://github.com/mayflower/mo4-coding-standard/pull/104#pullrequestreview-166609689
we want to have comments that actually tell the developer *why*
the comment itself is invalid or misplaced.

/cc @calbrecht