### PR TITLE
raise minimum Symfony CS release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "~7.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
-        "escapestudios/symfony2-coding-standard": "^3.0",
+        "escapestudios/symfony2-coding-standard": "^3.5.2",
         "slevomat/coding-standard": "^4.8.5",
         "squizlabs/php_codesniffer": "^3.3.1"
     }


### PR DESCRIPTION
* [x] Bugfix
* [ ] New Feature
* [x] Other (explain):

3.5.2 is required for the complete matrix of PHP and PHPCS versions to really work.