### PR TITLE
Fix PHPCS-CS violation with PHPCS 3.5

### DIFF
--- a/MO4/Sniffs/Arrays/ArrayDoubleArrowAlignmentSniff.php
+++ b/MO4/Sniffs/Arrays/ArrayDoubleArrowAlignmentSniff.php
@@ -27,6 +27,7 @@ use PHP_CodeSniffer\Util\Tokens as PHP_CodeSniffer_Tokens;
  */
 class ArrayDoubleArrowAlignmentSniff implements Sniff
 {
+
     /**
      * Define all types of arrays.
      *

--- a/MO4/Sniffs/Arrays/MultiLineArraySniff.php
+++ b/MO4/Sniffs/Arrays/MultiLineArraySniff.php
@@ -24,6 +24,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  */
 class MultiLineArraySniff implements Sniff
 {
+
     /**
      * Define all types of arrays.
      *

--- a/MO4/Sniffs/Commenting/PropertyCommentSniff.php
+++ b/MO4/Sniffs/Commenting/PropertyCommentSniff.php
@@ -29,6 +29,7 @@ use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
  */
 class PropertyCommentSniff extends AbstractScopeSniff
 {
+
     /**
      * A list of tokenizers this sniff supports.
      *

--- a/MO4/Sniffs/Strings/VariableInDoubleQuotedStringSniff.php
+++ b/MO4/Sniffs/Strings/VariableInDoubleQuotedStringSniff.php
@@ -26,6 +26,7 @@ use PHP_CodeSniffer\Files\File;
  */
 class VariableInDoubleQuotedStringSniff implements Sniff
 {
+
     /**
      * The PHP_CodeSniffer object controlling this run.
      *


### PR DESCRIPTION
### Type of PR

* [ ] Bugfix
* [ ] New Feature
* [x] Other (explain):

### Breaking changes

* [ ] Yes, this is a breaking change

<!-- If yes, please list the incompatible parts of your patch(es) -->

### Description

The PHPCS-CS itself changed with 3.5, this is only to fix the travis build.
