### PR TITLE
Require blank lines between class members

### DIFF
--- a/MO4/ruleset.xml
+++ b/MO4/ruleset.xml
@@ -46,6 +46,24 @@
         </properties>
     </rule>
 
+    <!-- Require one blank line between methods -->
+    <rule ref="Squiz.WhiteSpace.FunctionSpacing">
+        <properties>
+            <property name="spacing" value="1"/>
+            <property name="spacingAfterLast" value="0" />
+            <property name="spacingBeforeFirst" value="0" />
+        </properties>
+    </rule>
+    <!-- Require one blank line between properties -->
+    <rule ref="Squiz.WhiteSpace.MemberVarSpacing">
+        <properties>
+            <property name="spacingBeforeFirst" value="0"/>
+        </properties>
+    </rule>
+
+    <!-- Require exactly one blank line after trait use -->
+    <rule ref="PSR12.Traits.UseDeclaration"/>
+
     <!-- Require presence of constant visibility -->
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
     <!-- Forbid empty lines after class/interface/trait opening and before closing braces -->
@@ -148,6 +166,4 @@
             <property name="ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach" value="true"/>
         </properties>
     </rule>
-    <!-- Require exactly one blank line after trait use -->
-    <rule ref="PSR12.Traits.UseDeclaration"/>
 </ruleset>


### PR DESCRIPTION
### Type of PR

* [ ] Bugfix
* [X] New Feature
* [ ] Other (explain):

### Breaking changes

* [ ] Yes, this is a breaking change

<!-- If yes, please list the incompatible parts of your patch(es) -->

### Description

Require exactly one blank line between class members, but not before the first and after the last one.

Example:
 ```
class Test
{
    /**
     * @var string
     */
    private $first;
    /**
     * @var int
     */
    private $second;


    /**
     * Test constructor.
     */
    public function __construct()
    {
    }
}
```

would become:

 ```
class Test
{
    /**
     * @var string
     */
    private $first;

    /**
     * @var int
     */
    private $second;

    /**
     * Test constructor.
     */
    public function __construct()
    {
    }
}
```
