### PR TITLE
pull in SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
 
 script:
   - xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd MO4/ruleset.xml # validate MO4's ruleset XML
-  - vendor/bin/phpcs --standard=MO4 integrationtests/testfile.php # Check, if all the sniffs work with the current dependencies
+  - vendor/bin/phpcs -s --standard=MO4 integrationtests/testfile.php # Check, if all the sniffs work with the current dependencies
   - vendor/bin/phpunit # Run tests
   - vendor/bin/phpcs # Stylecheck against PHPCS's ruleset
   - vendor/bin/phpstan analyse --level=max --no-progress -c .phpstan.neon MO4 tests # Run PHPStan
@@ -55,7 +55,7 @@ jobs:
         - git config core.autocrlf false # fix CRLF issues
         - git add --renormalize .
         - git reset --hard
-        - vendor/bin/phpcs --standard=MO4 integrationtests/testfile.php # Check, if all the sniffs work with the current dependencies
+        - vendor/bin/phpcs -s --standard=MO4 integrationtests/testfile.php # Check, if all the sniffs work with the current dependencies
         - vendor/bin/phpunit # Run tests
         - vendor/bin/phpcs # Stylecheck against PHPCS's ruleset
         - vendor/bin/phpstan analyse --level=max --no-progress -c .phpstan.neon MO4 tests # Run PHPStan

--- a/MO4/ruleset.xml
+++ b/MO4/ruleset.xml
@@ -94,6 +94,8 @@
             <property name="ignoreMultiline" value="true"/>
         </properties>
     </rule>
+    <!-- Require global functions to be referenced via a fully qualified name -->
+    <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions"/>
     <!-- Forbid multiple use statements on same line -->
     <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
     <!-- Require one newline around namespace declaration -->

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ If `phpcs` complains that MO4 is not installed, please check the installed codin
 ## Dependencies
 
 * [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version 3.5 or later
-* [David Joos's Symfony Coding Standard](https://github.com/djoos/Symfony-coding-standard) version 3.0 or later
+* [David Joos's Symfony Coding Standard](https://github.com/djoos/Symfony-coding-standard) version 3.10 or later
 * [Composer installer for PHP_CodeSniffer coding standards](https://github.com/DealerDirect/phpcodesniffer-composer-installer)
 * [Slevomat Coding Standard](https://github.com/slevomat/coding-standard) version 4.8.5 or later
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "~7.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
-        "escapestudios/symfony2-coding-standard": "^3.9.2",
+        "escapestudios/symfony2-coding-standard": "^3.10.0",
         "slevomat/coding-standard": "^5.0.4",
         "squizlabs/php_codesniffer": "^3.5.0"
     }

--- a/integrationtests/testfile.php
+++ b/integrationtests/testfile.php
@@ -39,7 +39,7 @@ class FooBar
      */
     public function someDeprecatedMethod(): string
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 2.8 and will be removed in 3.0. Use Acme\Baz::someMethod() instead.', __METHOD__), E_USER_DEPRECATED);
+        @\trigger_error(\sprintf('The %s() method is deprecated since version 2.8 and will be removed in 3.0. Use Acme\Baz::someMethod() instead.', __METHOD__), E_USER_DEPRECATED);
 
         return Baz::someMethod();
     }
@@ -63,14 +63,14 @@ class FooBar
         ];
 
         foreach ($options as $option) {
-            if (!in_array($option, $defaultOptions)) {
-                throw new \RuntimeException(sprintf('Unrecognized option "%s"', $option));
+            if (!\in_array($option, $defaultOptions)) {
+                throw new \RuntimeException(\sprintf('Unrecognized option "%s"', $option));
             }
         }
 
-        $destructuredStuff = array_flip(...$defaultOptions);
+        $destructuredStuff = \array_flip(...$defaultOptions);
 
-        $mergedOptions = array_merge(
+        $mergedOptions = \array_merge(
             $defaultOptions,
             $options
         );
@@ -81,10 +81,10 @@ class FooBar
 
         if ('string' === $dummy) {
             if ('values' === $mergedOptions['some_default']) {
-                return substr($dummy, 0, 5);
+                return \substr($dummy, 0, 5);
             }
 
-            return ucwords($dummy);
+            return \ucwords($dummy);
         }
 
         return $destructuredStuff;


### PR DESCRIPTION
closes GH-80

### Type of PR

* [ ] Bugfix
* [ ] New Feature
* [ ] Other (explain):

### Breaking changes

* [ ] Yes, this is a breaking change

<!-- If yes, please list the incompatible parts of your patch(es) -->

### Description

Please explain what you want to change and why.
Additional information about the code and the commits
may be helpful as well.
