### PR TITLE
ruleset: disable `BlockControlStructureSpacing` sniff for most tokens

### DIFF
--- a/MO4/ruleset.xml
+++ b/MO4/ruleset.xml
@@ -102,12 +102,6 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing">
         <properties>
             <property name="tokensToCheck" type="array">
-                <element value="T_IF"/>
-                <element value="T_DO"/>
-                <element value="T_WHILE"/>
-                <element value="T_FOR"/>
-                <element value="T_FOREACH"/>
-                <element value="T_SWITCH"/>
                 <element value="T_TRY"/>
             </property>
         </properties>


### PR DESCRIPTION

### Type of PR

* [ ] Bugfix
* [ ] New Feature
* [x] Other (explain): request for a change in our ruleset.

### Breaking changes

* [ ] Yes, this is a breaking change

<!-- If yes, please list the incompatible parts of your patch(es) -->

### Description

I don't like this rule since variable assignments before such a block
shouldn't be a blank-line away if those are related to the block itself.

For instance

    $foo = 'bar';
    if ($this->returnBool($foo)) {
        // ...
    }

makes immediately clear that `$foo` is related to the control structure
in contrast to

    $foo = 'bar';

    if ($this->returnBool($foo)) {
        // ...
    }
