### PR TITLE
Fix AlphabeticalUseStatements sorting trait use statements

### DIFF
--- a/MO4/Sniffs/Formatting/AlphabeticalUseStatementsSniff.php
+++ b/MO4/Sniffs/Formatting/AlphabeticalUseStatementsSniff.php
@@ -106,6 +106,10 @@ class AlphabeticalUseStatementsSniff extends UseDeclarationSniff
 
         parent::process($phpcsFile, $stackPtr);
 
+        if (true === $this->checkIsNonImportUse($phpcsFile, $stackPtr)) {
+            return;
+        }
+
         if ($this->currentFile !== $phpcsFile->getFilename()) {
             $this->lastLine    = -1;
             $this->lastImport  = '';
@@ -114,13 +118,6 @@ class AlphabeticalUseStatementsSniff extends UseDeclarationSniff
 
         $tokens = $phpcsFile->getTokens();
         $line   = $tokens[$stackPtr]['line'];
-
-        // Ignore function () use () {...}.
-        $isNonImportUse = $this->checkIsNonImportUse($phpcsFile, $stackPtr);
-
-        if (true === $isNonImportUse) {
-            return;
-        }
 
         $currentImportArr = $this->getUseImport($phpcsFile, $stackPtr);
 
@@ -235,21 +232,14 @@ class AlphabeticalUseStatementsSniff extends UseDeclarationSniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $prev = $phpcsFile->findPrevious(
-            PHP_CodeSniffer_Tokens::EMPTY_TOKENS,
-            ($stackPtr - 1),
-            0,
-            true,
-            null,
-            true
-        );
+        // Ignore USE keywords for closures.
+        if (true === isset($tokens[$stackPtr]['parenthesis_owner'])) {
+            return true;
+        }
 
-        if (false !== $prev) {
-            $prevToken = $tokens[$prev];
-
-            if (T_CLOSE_PARENTHESIS === $prevToken['code']) {
-                return true;
-            }
+        // Ignore USE keywords for traits (inside class/trait/enum bodies).
+        if (true === $phpcsFile->hasCondition($stackPtr, [T_CLASS, T_TRAIT, T_ENUM])) {
+            return true;
         }
 
         return false;

--- a/MO4/Tests/Formatting/AlphabeticalUseStatementsUnitTest.pass.2.inc
+++ b/MO4/Tests/Formatting/AlphabeticalUseStatementsUnitTest.pass.2.inc
@@ -1,0 +1,19 @@
+<?php
+
+use A;
+use B;
+
+class Foo
+{
+    use ZebraTrait;
+    use AlphaTrait;
+}
+
+class Bar
+{
+    /** @use GenericTrait<string> */
+    use GenericTrait;
+    /** @use AnotherTrait<int> */
+    use AnotherTrait;
+}
+

--- a/MO4/Tests/Formatting/AlphabeticalUseStatementsUnitTest.pass.3.inc
+++ b/MO4/Tests/Formatting/AlphabeticalUseStatementsUnitTest.pass.3.inc
@@ -1,0 +1,8 @@
+<?php
+
+use A;
+use B;
+
+$closure = function () use ($b, $a) {
+    return $a + $b;
+};

--- a/MO4/Tests/Formatting/AlphabeticalUseStatementsUnitTest.php
+++ b/MO4/Tests/Formatting/AlphabeticalUseStatementsUnitTest.php
@@ -35,6 +35,8 @@ final class AlphabeticalUseStatementsUnitTest extends AbstractMo4SniffUnitTest
     protected $expectedErrorList = [
         'AlphabeticalUseStatementsUnitTest.pass.inc'   => [],
         'AlphabeticalUseStatementsUnitTest.pass.1.inc' => [],
+        'AlphabeticalUseStatementsUnitTest.pass.2.inc' => [],
+        'AlphabeticalUseStatementsUnitTest.pass.3.inc' => [],
         'AlphabeticalUseStatementsUnitTest.fail.1.inc' => [
             4  => 1,
             5  => 1,


### PR DESCRIPTION
### Type of PR

* [x] Bugfix

### Description

The sniff was incorrectly processing trait use statements inside class/trait/enum bodies. The parent class's private shouldIgnoreUse() filtered them out, but the child class continued executing its own sorting logic. Add a hasCondition() check to also ignore trait use.
In theory, this would sort trait use statements as well, but it does not handle traits with docblocks (generic traits are a thing).
I assume the entire handling of traits was a bug.

I thought about adding https://github.com/slevomat/coding-standard/blob/master/doc/classes.md#slevomatcodingstandardclassestraituseorder- and maybe  https://github.com/slevomat/coding-standard/blob/master/doc/classes.md#slevomatcodingstandardclassestraitusespacing- but those have also issues with docblocks on traits.